### PR TITLE
Fix Error "Extra parameters passed to parent construct: $data"

### DIFF
--- a/src/Helper/Currency.php
+++ b/src/Helper/Currency.php
@@ -19,7 +19,7 @@ class Currency extends AbstractHelper
         $this->_storeManager = $storeManager;
         $this->_currency = $currency;
 
-        parent::__construct($context, $data);
+        parent::__construct($context);
     }
 
     public function getCurrencyPriceForProduct($product)


### PR DESCRIPTION
Fix the Error "Extra parameters passed to parent construct: $data. File vendor/feedoptimise/magento2-catalog-export/src/Helper/Currency.php" when you run a compile: php bin/magento setup:di:compile